### PR TITLE
Correct ordered list setting in `Readme`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ apm install markdown-toc
 - Depth control [1-6] with `depthFrom:1` and `depthTo:6`
 - Enable or disable links with `withLinks:1`
 - Refresh list on save with `updateOnSave:1`
-- Use ordered list (1. ..., 2. ...) with `orderedList:0`
+- Use ordered list (1. ..., 2. ...) with `orderedList:1`
 
 ## Contributors
 


### PR DESCRIPTION
After reading the `Toc.coffee` script, I tested the `ordered` style. It shows only value `1` gives desired output.