### PR TITLE
Autoload

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Markdown TOC
 Generate and update magically a table of contents based on the headlines of a parsed [markdown](http://en.wikipedia.org/wiki/Markdown) file.
 
 
-## Table of Contents
+# Table of Contents
+<!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Usage](#usage)
 - [Installation](#installation)
@@ -13,20 +14,11 @@ Generate and update magically a table of contents based on the headlines of a pa
 - [Questions?](#questions)
 - [License](#license)
 
+<!-- /TOC -->
 
 ## Usage
 
 ![Magic](https://raw.githubusercontent.com/nok/markdown-toc/master/RECORD.gif)
-
-<!--
-## API Attributes
-
-- `depthFrom:1`
-- `depthTo:6`
-- `withLinks:1`
-- `updateOnSave:1`
-- `orderedList:0`
--->
 
 ## Installation
 

--- a/lib/Toc.coffee
+++ b/lib/Toc.coffee
@@ -24,6 +24,11 @@ class Toc
   # main methods (highest logic level)
 
 
+  init: ->
+    if @_hasToc()
+      @_readToc()
+
+
   create: ->
     if @_hasToc()
       @_deleteToc()
@@ -85,6 +90,17 @@ class Toc
           return true
     return false
 
+  _readToc: () ->
+    @__updateList()
+    if Object.keys(@list).length > 0
+      text = []
+      text.push "<!-- TOC depthFrom:"+@options.depthFrom+" depthTo:"+@options.depthTo+" withLinks:"+@options.withLinks+" updateOnSave:"+@options.updateOnSave+" orderedList:"+@options.orderedList+" -->\n"
+      list = @__createList()
+      if list isnt false
+        Array.prototype.push.apply text, list
+      text.push "\n<!-- /TOC -->"
+      return text.join "\n"
+    return ""
 
   # embed list with the open and close comment:
   # <!-- TOC --> [list] <!-- /TOC -->

--- a/lib/markdown-toc.coffee
+++ b/lib/markdown-toc.coffee
@@ -10,7 +10,7 @@ module.exports =
 
     at = @
     atom.workspace.onDidAddTextEditor (event) ->
-      at.init(event.textEditor)
+      at.initToc(event.textEditor)
 
   initToc: (thisEditor) ->
     thisGrammar = thisEditor.getGrammar().packageName

--- a/lib/markdown-toc.coffee
+++ b/lib/markdown-toc.coffee
@@ -13,21 +13,22 @@ module.exports =
       at.initToc(event.textEditor)
 
   initToc: (thisEditor) ->
-    thisGrammar = thisEditor.getGrammar().packageName
-    if thisGrammar.match /^.*(markdown|gfm).*$/g
-      @toc = new Toc(thisEditor)
-      @toc.init()
-      atom.commands.add 'atom-workspace', 'markdown-toc:create': =>
-          @toc = new Toc(thisEditor)
-          @toc.create()
-      atom.commands.add 'atom-workspace', 'markdown-toc:update': =>
-          @toc = new Toc(thisEditor)
-          @toc.update()
-      atom.commands.add 'atom-workspace', 'markdown-toc:delete': =>
-          @toc = new Toc(thisEditor);
-          @toc.delete()
-      atom.commands.add 'atom-workspace', 'markdown-toc:toggle': =>
-          @toc = new Toc(thisEditor)
-          @toc.toggle()
+    if thisEditor.getGrammar().packageName isnt undefined
+      thisGrammar = thisEditor.getGrammar().packageName
+      if thisGrammar.match /^.*(markdown|gfm).*$/g
+        @toc = new Toc(thisEditor)
+        @toc.init()
+        atom.commands.add 'atom-workspace', 'markdown-toc:create': =>
+            @toc = new Toc(thisEditor)
+            @toc.create()
+        atom.commands.add 'atom-workspace', 'markdown-toc:update': =>
+            @toc = new Toc(thisEditor)
+            @toc.update()
+        atom.commands.add 'atom-workspace', 'markdown-toc:delete': =>
+            @toc = new Toc(thisEditor);
+            @toc.delete()
+        atom.commands.add 'atom-workspace', 'markdown-toc:toggle': =>
+            @toc = new Toc(thisEditor)
+            @toc.toggle()
   # deactivate: ->
   #   @toc.destroy()

--- a/lib/markdown-toc.coffee
+++ b/lib/markdown-toc.coffee
@@ -3,18 +3,31 @@ Toc = require './Toc'
 module.exports =
 
   activate: (state) ->
-    atom.commands.add 'atom-workspace', 'markdown-toc:create': =>
-        @toc = new Toc(atom.workspace.getActivePaneItem())
-        @toc.create()
-    atom.commands.add 'atom-workspace', 'markdown-toc:update': =>
-        @toc = new Toc(atom.workspace.getActivePaneItem())
-        @toc.update()
-    atom.commands.add 'atom-workspace', 'markdown-toc:delete': =>
-        @toc = new Toc(atom.workspace.getActivePaneItem());
-        @toc.delete()
-    atom.commands.add 'atom-workspace', 'markdown-toc:toggle': =>
-        @toc = new Toc(atom.workspace.getActivePaneItem())
-        @toc.toggle()
+    editorCount = 0
+    while editorCount < atom.workspace.getTextEditors().length
+      @initToc(atom.workspace.getTextEditors()[editorCount])
+      editorCount++
 
+    at = @
+    atom.workspace.onDidAddTextEditor (event) ->
+      at.init(event.textEditor)
+
+  initToc: (thisEditor) ->
+    thisGrammar = thisEditor.getGrammar().packageName
+    if thisGrammar.match /^.*(markdown|gfm).*$/g
+      @toc = new Toc(thisEditor)
+      @toc.init()
+      atom.commands.add 'atom-workspace', 'markdown-toc:create': =>
+          @toc = new Toc(thisEditor)
+          @toc.create()
+      atom.commands.add 'atom-workspace', 'markdown-toc:update': =>
+          @toc = new Toc(thisEditor)
+          @toc.update()
+      atom.commands.add 'atom-workspace', 'markdown-toc:delete': =>
+          @toc = new Toc(thisEditor);
+          @toc.delete()
+      atom.commands.add 'atom-workspace', 'markdown-toc:toggle': =>
+          @toc = new Toc(thisEditor)
+          @toc.toggle()
   # deactivate: ->
   #   @toc.destroy()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-toc",
   "main": "./lib/markdown-toc",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Generate TOC (table of contents) of headlines from parsed markdown file",
   "activationCommands": {
     "atom-workspace": [
@@ -11,6 +11,11 @@
       "markdown-toc:delete"
     ]
   },
+  "activationHooks": [
+    "language-gfm:grammar-used",
+    "language-gfm-enhanced:grammar-used",
+    "language-markdown:grammar-used"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/nok/markdown-toc"


### PR DESCRIPTION
We can now read in an existing TOC when loading a markdown file.

- New addition: Activate when markdown grammar gets used

- On Activation, check all existing textEditors for markdown and assign a Toc object per textEditor using markdown. (Previously the Toc object was assigned to paneItems).

- On addition of new text editors (onDidAddTextEditor callback), check if it's using markdown and assign Toc object if necessary.

Downside: this could be more efficient - first textEditor to load a markdown file runs through init twice (on both `activate` hook and `onDidAddTextEditor` callback)